### PR TITLE
csexec: dynamic linker wrapper (x86_64 only for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get update -qq
 
 install:
-    - sudo apt-get install cmake valgrind
+    - sudo apt-get install cmake3 valgrind
     - sudo apt-get install -y --force-yes csbuild
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,14 @@ enable_testing()
 # initialize pthreads
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
-if(CMAKE_USE_PTHREADS_INIT)
-    add_definitions("-pthread")
-endif()
+add_definitions("-std=c99")
 
 # compile the executable, link with pthreads, and install
 add_executable(cswrap cswrap.c cswrap-util.c)
 target_link_libraries(cswrap ${CMAKE_THREAD_LIBS_INIT})
+if(CMAKE_USE_PTHREADS_INIT)
+    set_target_properties(cswrap PROPERTIES COMPILE_FLAGS "-pthread")
+endif()
 install(TARGETS cswrap DESTINATION bin)
 
 # build and install the man page (if asciidoc is available)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ if(CMAKE_USE_PTHREADS_INIT)
 endif()
 install(TARGETS cswrap DESTINATION bin)
 
+# build csexec only if supported by target (=host) architecture
+message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    message(STATUS "csexec for x86_64 will be built")
+    add_executable(csexec csexec.c)
+    install(TARGETS csexec DESTINATION bin)
+endif()
+
 # build and install the man page (if asciidoc is available)
 find_program(A2X a2x)
 if(A2X)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with cswrap.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 2.8)
+# using VERSION 3.3 or lower here causes cmake to link with -rdynamic
+cmake_minimum_required(VERSION 3.4)
 project(cswrap C)
 enable_testing()
 
@@ -32,12 +33,30 @@ if(CMAKE_USE_PTHREADS_INIT)
 endif()
 install(TARGETS cswrap DESTINATION bin)
 
+# build C unit with manually specified compiler/linker flags
+macro(build_custom_target dst src flags)
+    set(cmd ${CMAKE_C_COMPILER} ${flags} -o
+        ${CMAKE_CURRENT_BINARY_DIR}/${dst}
+        ${CMAKE_CURRENT_SOURCE_DIR}/${src})
+    string(REPLACE ";" " " flags_string "${flags}")
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${dst}
+        COMMAND ${cmd}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${src}
+        COMMENT "Building ${dst} with flags: ${flags_string}")
+    add_custom_target(${dst}-target ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${dst})
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${dst} DESTINATION bin)
+endmacro()
+
 # build csexec only if supported by target (=host) architecture
 message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     message(STATUS "csexec for x86_64 will be built")
     add_executable(csexec csexec.c)
     install(TARGETS csexec DESTINATION bin)
+
+    # csexec-loader (custom ELF interpreter) does not use any C run-time libs
+    set(loader_flags -Wall -Wextra -g -O2 -fPIC -shared -nostdlib)
+    build_custom_target(csexec-loader csexec-loader.c "${loader_flags}")
 endif()
 
 # build and install the man page (if asciidoc is available)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,29 @@ if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     add_executable(csexec csexec.c)
     install(TARGETS csexec DESTINATION bin)
 
+    # check whether /lib64/ld-linux-x86-64.so.2 takes --argv0, introduced with:
+    # https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c6702789
+    set(cmd "/lib64/ld-linux-x86-64.so.2 --argv0 XXX")
+    set(cmd "${cmd} /usr/sbin/iconvconfig --usage")
+    set(cmd "${cmd} | grep 'Usage: XXX' > /dev/null")
+    execute_process(COMMAND sh -c "${cmd}"
+        RESULT_VARIABLE LD_ARGV0_RESULT
+        ERROR_QUIET)
+    if("${LD_ARGV0_RESULT}" EQUAL 0)
+        message(STATUS "/lib64/ld-linux-x86-64.so.2 takes --argv0")
+        set(LD_ARGV0 ON)
+    else()
+        message(STATUS "/lib64/ld-linux-x86-64.so.2 does NOT take --argv0")
+        set(LD_ARGV0 OFF)
+    endif()
+    option(LD_LINUX_SO_TAKES_ARGV0
+        "Set to ON if ld-linux.so takes --argv0"
+        "${LD_ARGV0}")
+    if(${LD_LINUX_SO_TAKES_ARGV0})
+        set_target_properties(csexec PROPERTIES
+            COMPILE_FLAGS "-DLD_LINUX_SO_TAKES_ARGV0")
+    endif()
+
     # csexec-loader (custom ELF interpreter) does not use any C run-time libs
     set(loader_flags -Wall -Wextra -g -O2 -fPIC -shared -nostdlib)
     build_custom_target(csexec-loader csexec-loader.c "${loader_flags}")

--- a/csexec-loader.c
+++ b/csexec-loader.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This file is part of cswrap.
+ *
+ * cswrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * cswrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cswrap.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// path to csexec
+#ifndef CSEXEC_BIN
+#   define CSEXEC_BIN "/usr/bin/csexec"
+#endif
+
+// query real path of the executable
+static const char* dig_execfn(const char **argv, const char **env_ptr)
+{
+    // auxiliary vector entries (System V AMD64 ABI: Process Initialization)
+    // NOTE: if LD_SHOW_AUXV is exported, ld.so displays the auxiliary vector
+    enum {
+        AT_NULL     = 0,
+        AT_EXECFN   = 31
+    };
+    struct aux {
+        int         a_type;
+        const char *a_value;
+    };
+
+    // skip environment variables, the auxiliary vector is just behind them
+    while ((*env_ptr++));
+    const struct aux *paux = (const void *) env_ptr;
+
+    // go through auxiliary vector entries in the initial process stack
+    for (;;) {
+        switch (paux->a_type) {
+            case AT_NULL:
+                // not found --> fall back to argv[0]
+                return argv[0];
+
+            case AT_EXECFN:
+                // found!
+                return paux->a_value;
+
+            default:
+                // keep searching
+                ++paux;
+                continue;
+        }
+    }
+}
+
+// we do not start from main() to stay glibc-independent
+void _start(void)
+{
+    // read argc/argv from stack (System V AMD64 ABI: Process Initialization)
+    int argc;
+    const char **argv;
+    asm volatile (
+        "mov 0x08(%%rbp), %0;"      // argc
+        "lea 0x10(%%rbp), %1;"      // argv
+        : "=r" (argc)               // %0
+        , "=r" (argv)               // %1
+        ::);
+
+    // pointer to a NULL-terminated list of environment variables
+    const char **env = argc + argv + 1;
+
+    // allocate exec_args[] on stack
+    const char *exec_args[/* execfn */ 1 + argc + /* term */ 1];
+    int idx_dst = 0;
+
+    // query real path of the executable
+    exec_args[idx_dst++] = dig_execfn(argv, env);
+
+    // shallow copy of argv[] at the end of exec_args[]
+    int idx_src = 0;
+    while (idx_src < argc)
+        exec_args[idx_dst++] = argv[idx_src++];
+
+    // terminate exec_args[]
+    exec_args[idx_dst] = (void *) 0;
+
+    // execute syscall execve(CSEXEC_BIN, exec_args, env)
+    // doc: https://en.wikibooks.org/wiki/X86_Assembly/Interfacing_with_Linux
+    // and https://blog.rchapman.org/posts/Linux_System_Call_Table_for_x86_64
+    asm volatile (
+        "mov $59, %%rax;"           // execve()
+        "mov %0, %%rdi;"            // CSEXEC_BIN
+        "mov %1, %%rsi;"            // exec_args
+        "mov %2, %%rdx;"            // env
+        "syscall;"                  // x86_64 syscall insn
+        "mov $0x7F, %%rdi;"         // execve() has failed, handle it as ENOENT
+        "mov $60, %%rax;"           // exit()
+        "syscall" :
+        : "r" (CSEXEC_BIN)          // %0
+        , "r" (exec_args)           // %1
+        , "r" (env)                 // %2
+        : "rax", "rdi", "rsi", "rdx",
+        // needed for optimizer to see the contents of exec_args as still alive
+        "memory");
+}

--- a/csexec.c
+++ b/csexec.c
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -109,6 +110,12 @@ int main(int argc, char *argv[])
     // we require at least EXECFN (given as ARG0) and ARG0 (given as ARG1)
     if (argc < 2) {
         fprintf(stderr, "csexec: error: insufficient count of arguments\n");
+        return /* command not executable */ 0x7E;
+    }
+
+    // if csexec-loader is invoked directly, do not pass it to LD_LINUX_SO
+    if (!strcmp("csexec-loader", basename(argv[0]))) {
+        fprintf(stderr, "csexec: error: refusing to execute %s\n", argv[0]);
         return /* command not executable */ 0x7E;
     }
 

--- a/csexec.c
+++ b/csexec.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This file is part of cswrap.
+ *
+ * cswrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * cswrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cswrap.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE 
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// environment variable to read wrap_cmd from
+#ifndef CSEXEC_WRAP_CMD_ENV_VAR
+#   define CSEXEC_WRAP_CMD_ENV_VAR_NAME "CSEXEC_WRAP_CMD"
+#endif
+
+// executable of the dynamic linker (used as ELF interpreter)
+#ifndef LD_LINUX_SO
+#   define LD_LINUX_SO "/lib64/ld-linux-x86-64.so.2"
+#endif
+
+// set to 1 if dynamic linker supports the --argv0 option, as implemented with:
+// https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c6702789
+#ifndef LD_LINUX_SO_TAKES_ARGV0
+#   define LD_LINUX_SO_TAKES_ARGV0 0
+#endif
+
+// count BEL-separated arguments in wrap_cmd (including the command name)
+static int count_wrap_argc(const char *wrap_cmd)
+{
+    if (!wrap_cmd || !wrap_cmd[0])
+        // wrap_cmd unset or empty
+        return 0;
+
+    // count non-empty command
+    int wrap_argc = 1;
+
+    // count BEL-separated args
+    for (;;) {
+        switch (*wrap_cmd) {
+            case '\0':
+                // end of string
+                return wrap_argc;
+
+            case '\a':
+                // arg separator
+                ++wrap_argc;
+                // fall through!
+            default:
+                ++wrap_cmd;
+                continue;
+        }
+    }
+}
+
+// read BEL-separated arguments from wrap_cmd (including the command name)
+static bool read_wrap_cmd(char **exec_args, int *pidx, char *wrap_cmd)
+{
+    if (!wrap_cmd || !wrap_cmd[0])
+        // wrap_cmd unset or empty
+        return true;
+
+    for (;;) {
+        // seek BEL separator
+        char *const sep = strchr(wrap_cmd, '\a');
+        if (sep)
+            // temporarily replace BEL by NUL
+            *sep = '\0';
+
+        // the memory is going to be leaked on the subsequent call of exec()
+        char *const arg = strdup(wrap_cmd);
+        if (!arg)
+            return false;
+        exec_args[(*pidx)++] = arg;
+
+        if (!sep)
+            // all args have been processed
+            return true;
+
+        // restore the temporarily overwritten BEL char
+        *sep = '\a';
+
+        // move behind the separator
+        wrap_cmd = sep + 1;
+    }
+}
+
+// should be invoked as execve("/usr/bin/csexec", [EXECFN, ARG0, ...])
+int main(int argc, char *argv[])
+{
+    // we require at least EXECFN (given as ARG0) and ARG0 (given as ARG1)
+    if (argc < 2) {
+        fprintf(stderr, "csexec: error: insufficient count of arguments\n");
+        return /* command not executable */ 0x7E;
+    }
+
+    // compute the size of exec_args[]
+    char *wrap_cmd = getenv(CSEXEC_WRAP_CMD_ENV_VAR_NAME);
+    const int wrap_argc = count_wrap_argc(wrap_cmd);
+    int exec_args_size = wrap_argc + /* LD_LINUX_SO */ 1;
+#if LD_LINUX_SO_TAKES_ARGV0
+    exec_args_size += /* --argv0 */ 1 + /* ARG0 */ 1;
+#endif
+    exec_args_size += argc - /* ARG0 */ 1 + /* terminator */ 1;
+
+    // allocate exec_args[] on stack
+    char *exec_args[exec_args_size];
+    int idx_dst = 0;
+
+    // start with wrap_cmd if given
+    if (!read_wrap_cmd(exec_args, &idx_dst, wrap_cmd)) {
+        fprintf(stderr, "csexec: error: out of memory\n");
+        return /* command not executable */ 0x7E;
+    }
+
+    // explicitly invoke dynamic linker
+    exec_args[idx_dst++] = (char *) LD_LINUX_SO;
+#if LD_LINUX_SO_TAKES_ARGV0
+    exec_args[idx_dst++] = (char *) "--argv0";
+    exec_args[idx_dst++] = argv[/* ARG0 */ 1];
+#endif
+    exec_args[idx_dst++] = argv[/* EXECFN */ 0];
+
+    // shallow copy of other command-line arguments
+    int idx_src = 2;
+    while (idx_src < argc)
+        exec_args[idx_dst++] = argv[idx_src++];
+
+    // terminate exec_args[]
+    exec_args[idx_dst] = NULL;
+    assert(idx_dst + 1 == exec_args_size);
+
+    // execute exec_args[]
+    execvp(exec_args[0], exec_args);
+
+    // handle failure of execvp()
+    const int errno_execvp = errno;
+    fprintf(stderr, "cexec: error: failed to execute: %s (%s)\n",
+            exec_args[0], strerror(errno));
+
+    return (ENOENT == errno_execvp)
+        ? /* command not found      */ 0x7F
+        : /* command not executable */ 0x7E;
+}

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -143,6 +143,9 @@ do
 done
 
 %files
+%ifarch x86_64
+%{_bindir}/csexec
+%endif
 %{_bindir}/cswrap
 %{_libdir}/cswrap
 %{_mandir}/man1/%{name}.1*

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -145,6 +145,7 @@ done
 %files
 %ifarch x86_64
 %{_bindir}/csexec
+%{_bindir}/csexec-loader
 %endif
 %{_bindir}/cswrap
 %{_libdir}/cswrap


### PR DESCRIPTION
## csexec: dynamic linker wrapper (x86_64 only for now)

    This is a proof-of-concept execution wrapper.  The ultimate goal is to
    run dynamic analyzers and formal verifiers on RPM packages fully
    automatically.  We already know how to tweak the build process, how to
    hook static analyzers on compiler invocation, and how to capture their
    results.  This is, however, not so easy with dynamic analyzers.

    The %check section of RPM packages can use arbitrary testing frameworks
    and scripting languages to verify the binaries produced in the %build
    and %install sections.  Our goal is to dynamically analyze (or formally
    verify) the produced binaries.  At the same time, we want to interfere
    with all the testing frameworks as little as possible.

    This wrapper runs the dynamic linker explicitly.  Optionally, it inserts
    an execution wrapper if the CSEXEC_WRAP_CMD environment variable is set
    at run time.  The string may optionally contain BEL-separated list of
    arguments that will be passed to the wrapper in front of the path to the
    dynamic linker exectuable.

## csexec-loader: custom ELF interpreter to load csexec

    This binary can be set as ELF interpreter while linking binaries in
    %build and %install sections of RPM packages.  The wrapper executes
    /usr/bin/csexec passing it EXECFN as argv[0], followed by original
    command-line arguments.  Then csexec can optionally run the real
    wrapper if ${CSEXEC_WRAP_CMD} is set.  Otherwise csexec should take
    care of executing the original ELF file natively.

    There are some constrains on the implementation of ELF interpreters.
    Namely it does not work well if an ELF interpreter itself uses the
    original ELF interpreter or C run-time in general, which is tightly
    coupled with the system ELF interpreter.  Therefore this wrapper is
    implemented such that it does not rely on any C run-time libraries.

    Note that the current implementation will only work on the x86_64 arch.

## csexec: add compile-time check for `ld-linux.so --argv0`

The option was introduced with the following glibc commit:

https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c6702789