### PR TITLE
csexec-preload: override readlink() and canonicalize_file_name()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ if(CMAKE_USE_PTHREADS_INIT)
 endif()
 install(TARGETS cswrap DESTINATION bin)
 
+if(NOT DEFINED LIB_INSTALL_DIR)
+  set(LIB_INSTALL_DIR lib)
+endif()
+
 # build C unit with manually specified compiler/linker flags
 macro(build_custom_target dst src flags)
     set(cmd ${CMAKE_C_COMPILER} ${flags} -o
@@ -53,6 +57,12 @@ if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     message(STATUS "csexec for x86_64 will be built")
     add_executable(csexec csexec.c)
     install(TARGETS csexec DESTINATION bin)
+
+    # readlink() wrapper
+    add_library(csexec-preload SHARED csexec-preload.c)
+    set_target_properties(csexec-preload PROPERTIES LINK_FLAGS "-nostdlib")
+    target_link_libraries(csexec-preload dl)
+    install(TARGETS csexec-preload DESTINATION ${LIB_INSTALL_DIR})
 
     # check whether /lib64/ld-linux-x86-64.so.2 takes --argv0, introduced with:
     # https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c6702789

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,9 @@ if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
 
     # readlink() wrapper
     add_library(csexec-preload SHARED csexec-preload.c)
+    set_target_properties(csexec-preload PROPERTIES COMPILE_FLAGS "-pthread")
     set_target_properties(csexec-preload PROPERTIES LINK_FLAGS "-nostdlib")
-    target_link_libraries(csexec-preload dl)
+    target_link_libraries(csexec-preload dl pthread)
     install(TARGETS csexec-preload DESTINATION ${LIB_INSTALL_DIR})
 
     # check whether /lib64/ld-linux-x86-64.so.2 takes --argv0, introduced with:

--- a/csexec-preload.c
+++ b/csexec-preload.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This file is part of cswrap.
+ *
+ * cswrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * cswrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cswrap.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE 
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <error.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// environment variable to read the pretended target of /proc/self/exe from
+#ifndef CSEXEC_REAL_EXE_ENV_VAR_NAME
+#   define CSEXEC_REAL_EXE_ENV_VAR_NAME "CSEXEC_REAL_EXE"
+#endif
+
+// executable of the dynamic linker (used as ELF interpreter)
+#ifndef LD_LINUX_SO
+#   define LD_LINUX_SO "/lib64/ld-linux-x86-64.so.2"
+#endif
+
+// address of the original canonicalize_file_name()
+static char* (*orig_cfn)(const char *path);
+static void init_orig_cfn(void)
+{
+    // resolve the original symbol of canonicalize_file_name()
+    orig_cfn = dlsym(RTLD_NEXT, "canonicalize_file_name");
+    if (orig_cfn)
+        return;
+
+    error(1, 0, "csexec-preload: failed to bind canonicalize_file_name(): %s",
+            dlerror());
+}
+
+// address of the original readlink() we are going to wrap
+static ssize_t (*orig_readlink)(const char *, char *, size_t);
+static void init_orig_readlink(void)
+{
+    // resolve the original symbol of readlink()
+    orig_readlink = dlsym(RTLD_NEXT, "readlink");
+    if (orig_readlink)
+        return;
+
+    error(1, 0, "csexec-preload: failed to bind readlink(): %s", dlerror());
+}
+
+// real path of LD_LINUX_SO (which /proc/self/exe points at in case the ELF
+// interpreter is invoked explicitly)
+static char ld_so_real[0x100];
+static void init_ld_so_real(void)
+{
+    // resolve real path of LD_LINUX_SO
+    char *tmp = orig_cfn(LD_LINUX_SO);
+    if (!tmp || sizeof ld_so_real <= strlen(tmp)) {
+        error(1, errno, "csexec-preload: failed to canonicalize %s",
+                LD_LINUX_SO);
+    }
+
+    // store the result to our static buffer and release the heap object
+    strcpy(ld_so_real, tmp);
+    free(tmp);
+}
+
+// initialize global variables on first call
+static void init_once(void) {
+    if (!orig_cfn) {
+        // first call -> initialize global state
+        init_orig_cfn();
+        init_orig_readlink();
+        init_ld_so_real();
+    }
+}
+
+// return true if path is effectively /proc/self/exe
+static bool is_self_exe(const char *path)
+{
+    if (!strcmp("/proc/self/exe", path))
+        return true;
+
+    char *str;
+    if (-1 == asprintf(&str, "/proc/%d/exe", getpid()))
+        // OOM
+        return false;
+
+    const bool matched = !strcmp(str, path);
+    free(str);
+    return matched;
+}
+
+// our wrapper of the original canonicalize_file_name()
+char *canonicalize_file_name(const char *path)
+{
+    init_once();
+
+    // call the real canonicalize_file_name() using the code pointer
+    char *rv = orig_cfn(path);
+
+    if (!rv || !!strcmp(ld_so_real, rv))
+        // either failed or unrelated call to canonicalize_file_name()
+        return rv;
+
+    // check whether we should override the return value
+    const char *real_exe = getenv(CSEXEC_REAL_EXE_ENV_VAR_NAME);
+    if (!real_exe)
+        return rv;
+
+    // check whether path is something we should override
+    if (!is_self_exe(path))
+        return rv;
+
+    // free the originally returned value and duplicate the pretended one
+    free(rv);
+    return strdup(real_exe);
+}
+
+// our wrapper of the original readlink()
+ssize_t readlink(const char *path, char *buf, size_t bufsiz)
+{
+    init_once();
+
+    // call the real readlink() using the code pointer
+    const ssize_t rv = orig_readlink(path, buf, bufsiz);
+
+    if (rv < 0 || !!strncmp(ld_so_real, buf, rv))
+        // either failed or unrelated call to readlink()
+        return rv;
+
+    // check whether we should override the return value
+    const char *real_exe = getenv(CSEXEC_REAL_EXE_ENV_VAR_NAME);
+    if (!real_exe)
+        return rv;
+
+    // check whether path is something we should override
+    if (!is_self_exe(path))
+        return rv;
+
+    // copy the pretended value into the specified buffer and return its length
+    strncpy(buf, real_exe, bufsiz);
+    return strnlen(buf, bufsiz);
+}

--- a/csexec.c
+++ b/csexec.c
@@ -28,8 +28,13 @@
 #include <string.h>
 #include <unistd.h>
 
+// environment variable to read the pretended target of /proc/self/exe from
+#ifndef CSEXEC_REAL_EXE_ENV_VAR_NAME
+#   define CSEXEC_REAL_EXE_ENV_VAR_NAME "CSEXEC_REAL_EXE"
+#endif
+
 // environment variable to read wrap_cmd from
-#ifndef CSEXEC_WRAP_CMD_ENV_VAR
+#ifndef CSEXEC_WRAP_CMD_ENV_VAR_NAME
 #   define CSEXEC_WRAP_CMD_ENV_VAR_NAME "CSEXEC_WRAP_CMD"
 #endif
 
@@ -148,10 +153,13 @@ int main(int argc, char *argv[])
     // canonicalize argv[] in case we are called via shebang
     handle_shebang_exec(argv);
 
+    // export EXECFN for libcsexec-preload.so to override /proc/self/exe
+    setenv(CSEXEC_REAL_EXE_ENV_VAR_NAME, argv[0], /* overwrite */ 1);
+
     // compute the size of exec_args[]
     char *wrap_cmd = getenv(CSEXEC_WRAP_CMD_ENV_VAR_NAME);
     const int wrap_argc = count_wrap_argc(wrap_cmd);
-    int exec_args_size = wrap_argc + /* LD_LINUX_SO */ 1;
+    int exec_args_size = wrap_argc + /* LD_LINUX_SO */ 1 + /* preload */ 2;
 #if LD_LINUX_SO_TAKES_ARGV0
     exec_args_size += /* --argv0 */ 1 + /* ARG0 */ 1;
 #endif
@@ -169,6 +177,8 @@ int main(int argc, char *argv[])
 
     // explicitly invoke dynamic linker
     exec_args[idx_dst++] = (char *) LD_LINUX_SO;
+    exec_args[idx_dst++] = (char *) "--preload";
+    exec_args[idx_dst++] = (char *) "libcsexec-preload.so";
 #if LD_LINUX_SO_TAKES_ARGV0
     exec_args[idx_dst++] = (char *) "--argv0";
     exec_args[idx_dst++] = argv[/* ARG0 */ 1];

--- a/csexec.c
+++ b/csexec.c
@@ -28,11 +28,6 @@
 #include <string.h>
 #include <unistd.h>
 
-// environment variable to read the pretended target of /proc/self/exe from
-#ifndef CSEXEC_REAL_EXE_ENV_VAR_NAME
-#   define CSEXEC_REAL_EXE_ENV_VAR_NAME "CSEXEC_REAL_EXE"
-#endif
-
 // environment variable to read wrap_cmd from
 #ifndef CSEXEC_WRAP_CMD_ENV_VAR_NAME
 #   define CSEXEC_WRAP_CMD_ENV_VAR_NAME "CSEXEC_WRAP_CMD"
@@ -152,9 +147,6 @@ int main(int argc, char *argv[])
 
     // canonicalize argv[] in case we are called via shebang
     handle_shebang_exec(argv);
-
-    // export EXECFN for libcsexec-preload.so to override /proc/self/exe
-    setenv(CSEXEC_REAL_EXE_ENV_VAR_NAME, argv[0], /* overwrite */ 1);
 
     // compute the size of exec_args[]
     char *wrap_cmd = getenv(CSEXEC_WRAP_CMD_ENV_VAR_NAME);

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -47,7 +47,7 @@ VER="`echo "$VER" | sed "s/-.*-/.$TIMESTAMP./"`"
 
 BRANCH="`git rev-parse --abbrev-ref HEAD`"
 test -n "$BRANCH" || die "failed to get current branch name"
-test master = "${BRANCH}" || VER="${VER}.${BRANCH}"
+test master = "${BRANCH}" || VER="${VER}.${BRANCH//-/_}"
 test -z "`git diff HEAD`" || VER="${VER}.dirty"
 
 NV="${PKG}-${VER}"
@@ -81,6 +81,11 @@ Group:      Development/Tools
 License:    GPLv3+
 URL:        https://github.com/kdudka/%{name}
 Source0:    https://github.com/kdudka/%{name}/releases/download/%{name}-%{version}/%{name}-%{version}.tar.xz
+
+%ifarch x86_64
+# csexec (supported on x86_64 only for now) can be later moved to a subpackage
+Provides:   csexec = %{version}-%{release}
+%endif
 
 # cswrap-1.3.0+ emits internal warnings per timed out scans (used by csdiff to
 # eliminate false positivies that such a scan would otherwise cause) ==> force
@@ -146,6 +151,7 @@ done
 %ifarch x86_64
 %{_bindir}/csexec
 %{_bindir}/csexec-loader
+%{_libdir}/libcsexec-preload.so
 %endif
 %{_bindir}/cswrap
 %{_libdir}/cswrap


### PR DESCRIPTION
Some programs break if we invoke the ELF interpreter explicitly because they check `/proc/self/exe` which points to the ELF interpreter in that case.  This shared object instruments the library functions that check resolve symlinks to return the value of `${CSEXEC_REAL_EXE}` in this case.