### PR TITLE
csexec: do not run the system dynamic linker explicitly

### DIFF
--- a/csexec.c
+++ b/csexec.c
@@ -38,6 +38,10 @@
 #   define LD_LINUX_SO "/lib64/ld-linux-x86-64.so.2"
 #endif
 
+#ifndef LIBCSEXEC_PRELOAD_SO
+#   define LIBCSEXEC_PRELOAD_SO "libcsexec-preload.so"
+#endif
+
 // set to 1 if dynamic linker supports the --argv0 option, as implemented with:
 // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c6702789
 #ifndef LD_LINUX_SO_TAKES_ARGV0
@@ -177,7 +181,7 @@ int main(int argc, char *argv[])
         // explicitly invoke dynamic linker
         exec_args[idx_dst++] = (char *) LD_LINUX_SO;
         exec_args[idx_dst++] = (char *) "--preload";
-        exec_args[idx_dst++] = (char *) "libcsexec-preload.so";
+        exec_args[idx_dst++] = (char *) LIBCSEXEC_PRELOAD_SO;
 #if LD_LINUX_SO_TAKES_ARGV0
         exec_args[idx_dst++] = (char *) "--argv0";
         exec_args[idx_dst++] = argv[/* ARG0 */ 1];

--- a/csexec.c
+++ b/csexec.c
@@ -50,6 +50,17 @@
 #   define LD_LINUX_SO_TAKES_ARGV0 0
 #endif
 
+static int print_help(void)
+{
+    printf("Usage:\n\
+    csexec --print-ld-exec-cmd [argv0] prints a command prefix to invoke\n\
+    dynamic linker explicitly.\n\
+    \n\
+    csexec --help prints this text to standard output.\n");
+
+    return EXIT_SUCCESS;
+}
+
 // print a command prefix that can be used to invoke dynamic linker explicitly
 static int print_ld_exec_cmd(const char *argv0)
 {
@@ -170,6 +181,10 @@ int main(int argc, char *argv[])
     if (STREQ("csexec", execfn_base)) {
         const char *opt = argv[1];
         const char *optarg = argv[2];
+
+        if STREQ("--help", opt)
+            return print_help();
+
         if STREQ("--print-ld-exec-cmd", opt)
             return print_ld_exec_cmd(optarg);
     }

--- a/csexec.c
+++ b/csexec.c
@@ -19,6 +19,8 @@
 
 #define _GNU_SOURCE 
 
+#include "cswrap-util.h"
+
 #include <assert.h>
 #include <errno.h>
 #include <libgen.h>
@@ -125,7 +127,7 @@ static void handle_shebang_exec(char *argv[])
 
     // compare the interpreter specified with the shebang with exec_op
     char *exec_op = argv[1];
-    matched = !strcmp(buf, exec_op);
+    matched = STREQ(buf, exec_op);
     free(buf);
     if (!matched)
         return;
@@ -144,7 +146,8 @@ int main(int argc, char *argv[])
     }
 
     // if csexec-loader is invoked directly, do not pass it to LD_LINUX_SO
-    if (!strcmp("csexec-loader", basename(argv[0]))) {
+    const char *execfn_base = basename(argv[0]);
+    if (STREQ("csexec-loader", execfn_base)) {
         fprintf(stderr, "csexec: error: refusing to execute %s\n", argv[0]);
         return /* command not executable */ 0x7E;
     }
@@ -173,7 +176,7 @@ int main(int argc, char *argv[])
 
     // if ${CSEXEC_WRAP_CMD} starts with "--skip-ld-linux\a",
     // skip LD_LINUX_SO and directly run the command that follows
-    if (1 < wrap_argc && !strcmp("--skip-ld-linux", exec_args[0])) {
+    if (1 < wrap_argc && STREQ("--skip-ld-linux", exec_args[0])) {
         exec_file = exec_args[/* real wrap_cmd */ 1];
         exec_args[++exec_args_offset] = argv[/* ARG0 */ 1];
     }


### PR DESCRIPTION
... if `${CSEXEC_WRAP_CMD}` starts with `--skip-ld-linux`