### PR TITLE
cswrap: add support for di{os,v}cc, gllvm and goto-cc 

### DIFF
--- a/cswrap-util.c
+++ b/cswrap-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Red Hat, Inc.
+ * Copyright (C) 2013-2021 Red Hat, Inc.
  *
  * This file is part of cswrap.
  *
@@ -153,6 +153,13 @@ bool is_ignored_file(const char *name)
     /* used by librdkafka-1.6.0 */
     if (MATCH_PREFIX(name, "_mkltmp"))
         return true;
+
+    /* used by zlib */
+    if (MATCH_PREFIX(name, "ztest")) {
+        char cwd[PATH_MAX];
+        if (getcwd(cwd, sizeof cwd) && MATCH_PREFIX(basename(cwd), "zlib"))
+            return true;
+    }
 
     /* try.c in UU/ - used by perl-5.26.2 */
     if (STREQ(name, "try.c")) {

--- a/cswrap.c
+++ b/cswrap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Red Hat, Inc.
+ * Copyright (C) 2013-2021 Red Hat, Inc.
  *
  * This file is part of cswrap.
  *
@@ -896,6 +896,11 @@ int main(int argc, char *argv[])
         if (MATCH_PREFIX(argv[0], path_to_wrap))
             /* prevent LTO wrapper from picking cswrap again from argv[0] */
             argv[0] = exec_path;
+
+        if (STREQ(base_name, "gclang") || STREQ(base_name, "gclang++"))
+            /* prevent gllvm from creating bitcode files */
+            if (-1 == setenv("WLLVM_CONFIGURE_ONLY", "1", false))
+                return fail("putenv() failed: %s", strerror(errno));
 
         execv(exec_path, argv);
         return fail("execv() failed: %s", strerror(errno));

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -1,6 +1,6 @@
-#/bin/bash
+#!/bin/bash
 
-# Copyright (C) 2013-2014 Red Hat, Inc.
+# Copyright (C) 2013-2021 Red Hat, Inc.
 #
 # This file is part of cswrap.
 #
@@ -140,6 +140,7 @@ make install DESTDIR="\$RPM_BUILD_ROOT"
 
 install -m0755 -d "\$RPM_BUILD_ROOT%{_libdir}"{,/cswrap}
 for i in c++ cc g++ gcc clang clang++ cppcheck smatch \\
+    divc++ divcc diosc++ dioscc gclang++ gclang goto-gcc \\
     %{_arch}-redhat-linux-c++ \\
     %{_arch}-redhat-linux-g++ \\
     %{_arch}-redhat-linux-gcc


### PR DESCRIPTION
This PR adds support for compilers used by various formal verification tools and for recognition of `zlib`'s conftests.

Edit: typo